### PR TITLE
Fixed issue with null JSON values not being stored due to TypeError exception

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
+.idea
 node_modules
 npm-debug.log

--- a/lib/nconf-redis.js
+++ b/lib/nconf-redis.js
@@ -133,7 +133,12 @@ Redis.prototype.get = function (key, callback) {
           self.cache.set(key, result);
         }
 
-        callback(null, result);
+        try{
+          callback(null, result);
+        }
+        catch(ex){
+          return callback(ex);
+        }
       });
     }
   });

--- a/lib/nconf-redis.js
+++ b/lib/nconf-redis.js
@@ -31,17 +31,29 @@ var Redis = exports.Redis = function (options) {
   this.ttl       = options.ttl  || 60 * 60 * 1000;
   this.cache     = new nconf.Memory();
   this.redis     = redis.createClient(options.port, options.host);
-  
+  this.connect   = options.connect || null;
+  this.error     = options.error || null;
   this.redis.select(this.db);
-  
+
   if (options.auth) {
     this.redis.auth(options.auth);
   }
-  
+
+  // Add a listener on connect if requested
+  if (this.connect){
+    this.redis.on('connect',this.connect);
+  }
+
   // Suppress errors from the Redis client
-  this.redis.on('error', function (err) { 
-    console.dir(err);
-  });
+  if (this.error){
+    this.redis.on('error',this.error);
+  }
+  else
+  {
+    this.redis.on('error', function (err) {
+      console.dir(err);
+    });
+  }
 };
 
 //
@@ -62,10 +74,10 @@ Redis.prototype.get = function (key, callback) {
       now     = Date.now(),
       mtime   = this.cache.mtimes[key],
       fullKey = nconf.key(this.namespace, key);
-  
+
   // Set the callback if not provided for "fire and forget"
   callback = callback || function () { };
-  
+
   //
   // If the key exists in the cache and the ttl is less than 
   // the value set for this instance, return from the cache.
@@ -73,7 +85,7 @@ Redis.prototype.get = function (key, callback) {
   if (mtime && now - mtime < this.ttl) {
     return callback(null, this.cache.get(key));
   }
-  
+
   //
   // Get the set of all children keys for the `key` supplied. If the value
   // to be returned is an Object, this list will not be empty.
@@ -84,12 +96,12 @@ Redis.prototype.get = function (key, callback) {
         if (err) {
           return next(err);
         }
-        
+
         result[source] = value;
         next();
       });
     }
-    
+
     if (keys && keys.length > 0) {
       //
       // If the value to be retrieved is an Object, recursively attempt
@@ -100,7 +112,7 @@ Redis.prototype.get = function (key, callback) {
         if (err) {
           return callback(err);
         }
-        
+
         self.cache.set(key, result);
         callback(null, result);
       })
@@ -114,13 +126,13 @@ Redis.prototype.get = function (key, callback) {
         if (err) {
           return callback(err);
         }
-        
+
         result = JSON.parse(value);
         result = (result == null) ? undefined : result;
         if (result) {
           self.cache.set(key, result);
         }
-        
+
         callback(null, result);
       });
     }
@@ -137,17 +149,17 @@ Redis.prototype.get = function (key, callback) {
 Redis.prototype.set = function (key, value, callback) {
   var self = this,
       path = nconf.path(key);
-  
+
   // Set the callback if not provided for "fire and forget"
   callback = callback || function () { };
-  
+
   this._addKeys(key, function (err) {
     if (err) {
       return callback(err);
     }
-    
+
     var fullKey = nconf.key(self.namespace, key);
-    
+
     if (!Array.isArray(value) && value !== null && typeof value === 'object') {
       //
       // If the value is an `Object` (and not an `Array`) then
@@ -188,14 +200,14 @@ Redis.prototype.merge = function (key, value, callback) {
   if (typeof value !== 'object' || Array.isArray(value)) {
     return this.set(key, value, callback);
   }
-  
+
   var self    = this,
       path    = nconf.path(key),
       fullKey = nconf.key(this.namespace, key);
-  
+
   // Set the callback if not provided for "fire and forget"
   callback = callback || function () { };
-  
+
   //
   // Get the set of all children keys for the `key` supplied. If the value
   // to be returned is an Object, this list will not be empty.
@@ -206,7 +218,7 @@ Redis.prototype.merge = function (key, value, callback) {
         var keyPath = nconf.key.apply(null, path.concat([nested]));
         self.merge(keyPath, value[nested], next);
       }
-      
+
       if (keys && keys.length > 0) {
         //
         // If there are existing keys then we must do a recursive merge 
@@ -244,7 +256,7 @@ Redis.prototype.clear = function (key, callback) {
   // Clear the key from the cache for this instance
   //
   this.cache.clear(key);
-  
+
   //
   // Remove the `key` from the parent set of keys.
   //
@@ -261,7 +273,7 @@ Redis.prototype.clear = function (key, callback) {
         //
         self.clear(nconf.key(key, child), next);
       }
-       
+
       if (keys && keys.length > 0) {
         //
         // If there are child keys then iterate over them, 
@@ -291,10 +303,10 @@ Redis.prototype.save = function (value, callback) {
   if (Array.isArray(value) || typeof value !== 'object') {
     return callback(new Error('`value` to be saved must be an object.'));
   }
-  
+
   var self = this,
       keys = Object.keys(value);
-  
+
   // Set the callback if not provided for "fire and forget"
   callback = callback || function () { };
 
@@ -305,7 +317,7 @@ Redis.prototype.save = function (value, callback) {
     if (err) {
       return callback(err);
     }
-    
+
     //
     // Iterate over the keys in the new value, setting each of them.
     //
@@ -323,7 +335,7 @@ Redis.prototype.save = function (value, callback) {
 Redis.prototype.load = function (callback) {
   var self   = this,
       result = {};
-  
+
   // Set the callback if not provided for "fire and forget"
   callback = callback || function () { };
 
@@ -337,12 +349,12 @@ Redis.prototype.load = function (callback) {
         if (err) {
           return next(err);
         }
-        
+
         result[key] = value;
         next();
       });
     }
-    
+
     keys = keys || [];
     async.forEach(keys, addValue, function (err) {
       return err ? callback(err) : callback(null, result);
@@ -357,10 +369,10 @@ Redis.prototype.load = function (callback) {
 //
 Redis.prototype.reset = function (callback) {
   var self = this;
-  
+
   // Set the callback if not provided for "fire and forget"
   callback = callback || function () { };
-  
+
   //
   // Get the list of of top-level keys, then clear each of them
   //
@@ -368,7 +380,7 @@ Redis.prototype.reset = function (callback) {
     if (err) {
       return callback(err);
     }
-    
+
     existing = existing || [];
     async.forEach(existing, function (key, next) {
       self.clear(key, next);
@@ -385,7 +397,7 @@ Redis.prototype.reset = function (callback) {
 Redis.prototype._addKeys = function (key, callback) {
   var self = this,
       path = nconf.path(key);
-  
+
   function addKey (partial, next) {
     var index  = path.indexOf(partial),
         base   = [self.namespace].concat(path.slice(0, index)),
@@ -416,7 +428,7 @@ Redis.prototype._setObject = function (key, value, callback) {
     keys = Object.keys(value);
   else
     keys = [];
-  
+
   function addValue (child, next) {
     //
     // Add the child key to the parent key-set, then set the value.
@@ -429,7 +441,7 @@ Redis.prototype._setObject = function (key, value, callback) {
 
       var fullKey = nconf.key(key, child),
           childValue = value[child];
-          
+
       if (!Array.isArray(childValue) && typeof childValue === 'object') {
         self._setObject(fullKey, childValue, next);
       }
@@ -439,11 +451,11 @@ Redis.prototype._setObject = function (key, value, callback) {
       }
     });
   }
-  
+
   //
   // Iterate over the keys of the Object and set the appropriate values.
   //
   async.forEach(keys, addValue, function (err) {
-    return err ? callback(err) : callback();    
+    return err ? callback(err) : callback();
   });
 };

--- a/lib/nconf-redis.js
+++ b/lib/nconf-redis.js
@@ -410,7 +410,12 @@ Redis.prototype._addKeys = function (key, callback) {
 //
 Redis.prototype._setObject = function (key, value, callback) {
   var self = this,
-      keys = Object.keys(value);
+      keys;
+
+  if (value != null && typeof value === 'object')
+    keys = Object.keys(value);
+  else
+    keys = [];
   
   function addValue (child, next) {
     //

--- a/package.json
+++ b/package.json
@@ -5,12 +5,12 @@
   "author": "Charlie Robbins <charlie.robbins@gmail.com>",
   "repository": {
     "type": "git",
-    "url": "http://github.com/indexzero/nconf-redis.git" 
+    "url": "http://github.com/indexzero/nconf-redis.git"
   },
   "keywords": ["configuration", "key value store", "nconf", "redis"],
   "dependencies": {
-    "async": "0.1.x",
-    "redis": "0.7.x"
+    "async": "0.x",
+    "redis": "0.x"
   },
   "devDependencies": {
     "nconf": "0.5.x",


### PR DESCRIPTION
Fixes issue #6.

The fix checks if the value is not null and is of type 'object', if not it will create an empty array which will keep the desired behavior without throwing an exception.

I hope it makes sense and you'll find this useful.

Regards,
Itay
