### PR TITLE
nconf.get() returns the entire configuration object

### DIFF
--- a/lib/nconf-redis.js
+++ b/lib/nconf-redis.js
@@ -73,7 +73,11 @@ Redis.prototype.get = function (key, callback) {
   if (mtime && now - mtime < this.ttl) {
     return callback(null, this.cache.get(key));
   }
-  
+
+  if(!key) {
+    return callback(null, this.cache.get());
+  }
+
   //
   // Get the set of all children keys for the `key` supplied. If the value
   // to be returned is an Object, this list will not be empty.

--- a/lib/nconf-redis.js
+++ b/lib/nconf-redis.js
@@ -414,8 +414,8 @@ Redis.prototype._addKeys = function (key, callback) {
 //
 Redis.prototype._setObject = function (key, value, callback) {
   var self = this,
-      keys = Object.keys(value);
-  
+      keys = value !== null && typeof value === 'object' ? Object.keys(value) : [];
+
   function addValue (child, next) {
     //
     // Add the child key to the parent key-set, then set the value.


### PR DESCRIPTION
Normally, calling nconf.get without any arguments will return the entire configuration object. Since I'm using nconf as a layer of abstraction over multiple configuration stores, it is important that the behavior is consistent.
